### PR TITLE
V1.2 enlive visualizer added

### DIFF
--- a/src/instaparse/viz.clj
+++ b/src/instaparse/viz.clj
@@ -12,3 +12,28 @@
                    :node->descriptor (fn [n] {:label (if (vector? n) 
                                                        (first n) 
                                                        (when (string? n) n ))})))
+
+(def make-tree
+     "simple tree parser"
+     (instaparse.core/parser "tree: node* 
+              node: leaf | <'('> node (<'('> node <')'>)* node* <')'> 
+              leaf: #'a+'
+              " :output-format :enlive))
+              
+(defn- enlive-seq
+  [tree]
+  (if (map? tree)          
+      (:content tree)
+      (first tree)))
+
+(defn- kids? [node]
+  (not (= nil (:content node))))
+
+(defn e-tree-viz
+  "visualize enlive trees"
+  [mytree]
+  (r/view-tree kids? enlive-seq mytree 
+             :node->descriptor (fn [n] 
+                                 {:label (if (string? n)
+                                             n
+                                             (:tag n))})))


### PR DESCRIPTION
Included is a separate function for enlive output. Next step would be to make tree-viz auto-detect output format and behave accordingly. 

I also believe the support functions could be substantially simplified. I quit when it worked.

Note that the require trick does not load rhizome on my system, where it is available. I have tested the code in my sandbox, where it generates correct output for at least the input "a(a)a" on the toy tree parser "tree: node\* node: leaf | <'('> node (<'('> node <')'>)\* node\* <')'> leaf: #'a+' ".
