### PR TITLE
Class name mismatch when packaging in uberjar

### DIFF
--- a/src/instaparse/core.clj
+++ b/src/instaparse/core.clj
@@ -82,7 +82,7 @@
 
 (defmethod clojure.core/print-method Parser [x writer]
   (binding [*out* writer]
-    (println (print/Parser->str x))))
+    (println (print/pparser->str x))))
 
 (defn parser
   "Takes a string specification of a context-free grammar,

--- a/src/instaparse/print.clj
+++ b/src/instaparse/print.clj
@@ -63,7 +63,7 @@
        " = " 
        (parser->str parser)))
 
-(defn Parser->str
+(defn pparser->str
   "Takes a Parser object, i.e., something with a grammar map and a start 
    production keyword, and stringifies it." 
   [{grammar :grammar start :start-production}]


### PR DESCRIPTION
When using instaparse in a library that is going to be packaged up in an uber-jar, the capital name for print/Parser is causing the class not to be found.  Renaming the function to lowercase fixes the issue. 

babar git:(master) ✗ java -jar /Users/cmeier/workspace/clojureland/workspace/babar/target/babar-0.1.0-SNAPSHOT-standalone.jar
Exception in thread "main" java.lang.NoClassDefFoundError: instaparse/print$parser__GT_str (wrong name: instaparse/print$Parser__GT_str)
    at java.lang.ClassLoader.defineClass1(Native Method)
    at java.lang.ClassLoader.defineClass(ClassLoader.java:791)
    at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
    at java.net.URLClassLoader.defineClass(URLClassLoader.java:449)
    at java.net.URLClassLoader.access$100(URLClassLoader.java:71)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:361)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:355)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:354)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:423)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:308)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:356)

➜  babar git:(master) ✗ jar -tvf ./target/babar-0.1.0-SNAPSHOT.jar | grep print
  1586 Mon Jun 03 15:05:06 EDT 2013 babar/commands$babar_println.class
  5262 Mon Jun 03 15:05:02 EDT 2013 instaparse/failure$pprint_failure.class
  2241 Mon Jun 03 15:05:02 EDT 2013 instaparse/failure$print_reason.class
  1636 Mon Jun 03 15:05:04 EDT 2013 instaparse/gll$dpprint.class
  1618 Mon Jun 03 15:05:04 EDT 2013 instaparse/gll$dprintln.class
  1786 Mon Jun 03 15:05:02 EDT 2013 instaparse/print$fn__43.class
  1850 Mon Jun 03 15:05:02 EDT 2013 instaparse/print$loading__4910__auto__.class
  1462 Mon Jun 03 15:05:02 EDT 2013 instaparse/print$paren_for_tags.class
  2095 Mon Jun 03 15:05:02 EDT 2013 instaparse/print$Parser__GT_str$iter__58__62$fn__63$fn__64.class
  3145 Mon Jun 03 15:05:02 EDT 2013 instaparse/print$Parser__GT_str$iter__58__62$fn__63.class
   859 Mon Jun 03 15:05:02 EDT 2013 instaparse/print$Parser__GT_str$iter__58__62.class
  2175 Mon Jun 03 15:05:02 EDT 2013 instaparse/print$parser__GT_str.class
  1553 Mon Jun 03 15:05:02 EDT 2013 instaparse/print$regexp__GT_str.class
  1124 Mon Jun 03 15:05:02 EDT 2013 instaparse/print$regexp_replace.class
  1341 Mon Jun 03 15:05:02 EDT 2013 instaparse/print$rule__GT_str.class
  6818 Mon Jun 03 15:05:02 EDT 2013 instaparse/print__init.class
