### PR TITLE
Fixed an exception thrown from illegal characters in a regex

### DIFF
--- a/src/instaparse/abnf.clj
+++ b/src/instaparse/abnf.clj
@@ -4,7 +4,8 @@
             [instaparse.cfg :as cfg]
             [instaparse.gll :as gll]
             [instaparse.reduction :as red])
-  (:use instaparse.combinators-source))
+  (:use instaparse.combinators-source)
+  (:import java.util.regex.Pattern))
 
 (def ^:dynamic *case-insensitive*
   "This is normally set to false, in which case the non-terminals
@@ -79,10 +80,15 @@ regexp = #\"#'[^'\\\\]*(?:\\\\.[^'\\\\]*)*'(?x) #Single-quoted regexp\"
        | #\"#\\\"[^\\\"\\\\]*(?:\\\\.[^\\\"\\\\]*)*\\\"(?x) #Double-quoted regexp\"
 ")
 
+(defn escape-char
+  "Use Pattern's quote method to escape illegal characters in a regex."
+  [unescaped-char]
+  (Pattern/quote (str unescaped-char)))
+
 (defn char-range
   "Takes two chars and returns a combinator representing a range of characters."
   [char1 char2]
-  (regexp (str "[" char1 "-" char2 "]")))
+  (regexp (str "[" (escape-char char1) "-" (escape-char char2) "]")))
 
 (defn get-char-combinator
   ([num1]

--- a/test/instaparse/abnf_test.clj
+++ b/test/instaparse/abnf_test.clj
@@ -119,3 +119,6 @@ to test the lookahead"
        (reps "")
        (reps "bccddee")
        (reps "aaaabbbbcccddee")))
+
+(deftest char-range-exception
+  (is (instaparse.abnf/char-range (char 91) (char 92))))


### PR DESCRIPTION
While writing a library to parse RFC 5322, the specification for a valid email address, I came across a bug that will cause an exception when creating regular expressions for character ranges.  Specifically it was from this (partial) case:

ctext = %d42-91

I am new to Clojure, so there are probably better and cleaner ways to solve this. Please feel free to modify and give critique, I welcome the feedback.
