### PR TITLE
If all else fails, try slurping.

### DIFF
--- a/src/instaparse/core.clj
+++ b/src/instaparse/core.clj
@@ -181,6 +181,11 @@
                 (cfg/build-parser-from-combinators (apply hash-map grammar-specification)
                                                    output-format
                                                    start)]
+            (map->Parser parser))
+
+          :else
+          (let [spec (slurp grammar-specification)
+                parser (build-parser spec output-format)]
             (map->Parser parser)))]
     
     (if-let [{ws-grammar :grammar ws-start :start-production}


### PR DESCRIPTION
Howdy. I was wondering if you'd be interested in this change.

Right now you can pass a string (potentially containing a URI), vector, map, but other things aren't handled. It is frequently convenient to be able to use `clojure.java.io/resource` for fetching resources off the classpath. In particular, this change enables the following:

``` clojure
(require '[clojure.java.io :as io]
            '[instaparse.core :as insta])

(insta/parser (io/resource "foo.bnf"))
```

In fact, anything that is readable by `clojure.java.io/reader` can now be passed in.

Thoughts? Also, I would have written tests for this, but I couldn't find any tests for the URL slurping behavior (which is where I would have liked to put tests for this). I'd still be happy to add them if you point me to where you'd like them added (assuming you're interested in this change, of course)!

Cheers!
