### PR TITLE
use Clojure 1.6.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                     [criterium "0.3.1"]
                     [rhizome "0.1.8"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
-             :1.6 {:dependencies [[org.clojure/clojure "1.6.0-beta1"]]}}
+             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}}
   :aliases {"test-all" ["with-profile" "+1.5:+1.6" "test"]}
   :test-paths ["test"]
   :target-path "target"


### PR DESCRIPTION
Update it to use Clojure 1.6.0 for the 1.6 profile. `lein test-all` passes on my machine.
