### PR TITLE
Text as CharSequence

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject instaparse "1.3.4"
+(defproject instaparse "1.3.5-SNAPSHOT"
   :description "Instaparse: No grammar left behind"
   :url "https://github.com/Engelberg/instaparse"
   :license {:name "Eclipse Public License"

--- a/src/instaparse/core.clj
+++ b/src/instaparse/core.clj
@@ -51,7 +51,7 @@
    :total true      (if parse fails, embed failure node in tree)
    :unhide <:tags or :content or :all> (for this parse, disable hiding)
    :optimize :memory   (when possible, employ strategy to use less memory)"
-  [parser text &{:as options}]
+  [parser ^CharSequence text &{:as options}]
   {:pre [(contains? #{:tags :content :all nil} (get options :unhide))
          (contains? #{:memory nil} (get options :optimize))]}
   (let [start-production 
@@ -92,7 +92,7 @@
    :partial true    (parses that don't consume the whole string are okay)
    :total true      (if parse fails, embed failure node in tree)
    :unhide <:tags or :content or :all> (for this parse, disable hiding)"
-  [parser text &{:as options}]
+  [parser ^CharSequence text &{:as options}]
   {:pre [(contains? #{:tags :content :all nil} (get options :unhide))]}
   (let [start-production 
         (get options :start (:start-production parser)),

--- a/src/instaparse/gll.clj
+++ b/src/instaparse/gll.clj
@@ -314,7 +314,8 @@
   (when (= index (:fail-index tramp))
     (success tramp node-key 
              (build-node-with-meta
-               (:node-builder tramp) :instaparse/failure (subs (:text tramp) index)
+               (:node-builder tramp) :instaparse/failure
+               (.subSequence (:text tramp) index (count (:text tramp)))
                index (count (:text tramp)))
              (count (:text tramp)))))
 
@@ -486,7 +487,7 @@
   (let [string (:string this)
         text (:text tramp)
         end (min (count text) (+ index (count string)))
-        head (subs text index end)]      
+        head (.subSequence text index end)]      
     (if (= string head)
       (success tramp [index this] string end)
       (fail tramp [index this] index
@@ -497,7 +498,7 @@
   (let [string (:string this)
         text (:text tramp)
         end (min (count text) (+ index (count string)))
-        head (subs text index end)]      
+        head (.subSequence text index end)]      
     (if (and (= end (count text)) (= string head))
       (success tramp [index this] string end)
       (fail tramp [index this] index
@@ -508,7 +509,7 @@
   (let [string (:string this)
         text (:text tramp)
         end (min (count text) (+ index (count string)))
-        head (subs text index end)]      
+        head (.subSequence text index end)]      
     (if (.equalsIgnoreCase ^String string head)
       (success tramp [index this] string end)
       (fail tramp [index this] index
@@ -519,7 +520,7 @@
   (let [string (:string this)
         text (:text tramp)
         end (min (count text) (+ index (count string)))
-        head (subs text index end)]      
+        head (.subSequence text index end)]      
     (if (and (= end (count text)) (.equalsIgnoreCase ^String string head))
       (success tramp [index this] string end)
       (fail tramp [index this] index
@@ -703,7 +704,8 @@
 ;(defn negative-lookahead-parse
 ;  [this index tramp]
 ;  (let [parser (:parser this)
-;        remaining-text (subs (:text tramp) index)]
+;        text (:text tramp)
+;        remaining-text (.subSequence text index (.length text))]
 ;    (if (negative-parse? (:grammar tramp) parser remaining-text)
 ;      (success tramp [index this] nil index)
 ;      (fail tramp index :negative-lookahead))))

--- a/src/instaparse/gll.clj
+++ b/src/instaparse/gll.clj
@@ -116,6 +116,13 @@
   [^CharSequence text]
   (Segment. text 0 (count text)))
 
+(defn sub-sequence
+  "Like clojure.core/subs but consumes and returns a CharSequence"
+  (^CharSequence [^CharSequence text start]
+     (.subSequence text start (.length text)))
+  (^CharSequence [^CharSequence text start end]
+     (.subSequence text start end)))
+
 ; The trampoline structure contains the grammar, text to parse, a stack and a nodes
 ; Also contains an atom to hold successes and one to hold index of failure point.
 ; grammar is a map from non-terminals to parsers
@@ -315,7 +322,7 @@
     (success tramp node-key 
              (build-node-with-meta
                (:node-builder tramp) :instaparse/failure
-               (.subSequence (:text tramp) index (count (:text tramp)))
+               (sub-sequence (:text tramp) index)
                index (count (:text tramp)))
              (count (:text tramp)))))
 
@@ -487,7 +494,7 @@
   (let [string (:string this)
         text (:text tramp)
         end (min (count text) (+ index (count string)))
-        head (.subSequence text index end)]      
+        head (sub-sequence text index end)]      
     (if (= string head)
       (success tramp [index this] string end)
       (fail tramp [index this] index
@@ -498,7 +505,7 @@
   (let [string (:string this)
         text (:text tramp)
         end (min (count text) (+ index (count string)))
-        head (.subSequence text index end)]      
+        head (sub-sequence text index end)]      
     (if (and (= end (count text)) (= string head))
       (success tramp [index this] string end)
       (fail tramp [index this] index
@@ -509,7 +516,7 @@
   (let [string (:string this)
         text (:text tramp)
         end (min (count text) (+ index (count string)))
-        head (.subSequence text index end)]      
+        head (sub-sequence text index end)]      
     (if (.equalsIgnoreCase ^String string head)
       (success tramp [index this] string end)
       (fail tramp [index this] index
@@ -520,7 +527,7 @@
   (let [string (:string this)
         text (:text tramp)
         end (min (count text) (+ index (count string)))
-        head (.subSequence text index end)]      
+        head (sub-sequence text index end)]      
     (if (and (= end (count text)) (.equalsIgnoreCase ^String string head))
       (success tramp [index this] string end)
       (fail tramp [index this] index
@@ -536,7 +543,7 @@
   [this index tramp]
   (let [regexp (:regexp this)
         ^Segment text (:segment tramp)
-        substring (.subSequence text index (.length text))
+        substring (sub-sequence text index)
         match (re-match-at-front regexp substring)]
     (if match
       (success tramp [index this] match (+ index (count match)))
@@ -547,7 +554,7 @@
   [this index tramp]
   (let [regexp (:regexp this)
         ^Segment text (:segment tramp)
-        substring (.subSequence text index (.length text))
+        substring (sub-sequence text index)
         match (re-match-at-front regexp substring)
         desired-length (- (count text) index)]
     (if (and match (= (count match) desired-length))
@@ -704,8 +711,7 @@
 ;(defn negative-lookahead-parse
 ;  [this index tramp]
 ;  (let [parser (:parser this)
-;        text (:text tramp)
-;        remaining-text (.subSequence text index (.length text))]
+;        remaining-text (sub-sequence (:text tramp) index)]
 ;    (if (negative-parse? (:grammar tramp) parser remaining-text)
 ;      (success tramp [index this] nil index)
 ;      (fail tramp index :negative-lookahead))))

--- a/src/instaparse/gll.clj
+++ b/src/instaparse/gll.clj
@@ -126,7 +126,7 @@
 ; The trampoline structure contains the grammar, text to parse, a stack and a nodes
 ; Also contains an atom to hold successes and one to hold index of failure point.
 ; grammar is a map from non-terminals to parsers
-; text is a string
+; text is a CharSequence
 ; stack is an atom of a vector containing items implementing the Execute protocol.
 ; nodes is an atom containing a map from [index parser] pairs to Nodes
 ; success contains a successful parse

--- a/src/instaparse/gll.clj
+++ b/src/instaparse/gll.clj
@@ -33,7 +33,7 @@
 ;; to support the use of instaparse on Google App Engine,
 ;; we simply create our own Segment type.
 
-(deftype Segment [^String s ^int offset ^int count]
+(deftype Segment [^CharSequence s ^int offset ^int count]
   CharSequence
   (length [this] count)
   (subSequence [this start end]
@@ -41,7 +41,8 @@
   (charAt [this index]
     (.charAt s (+ offset index)))
   (toString [this]
-    (.substring s offset (+ offset count))))
+    (.toString (doto (StringBuilder. count)
+                 (.append s offset (+ offset count))))))
 
 (def DEBUG false)
 (def PRINT false)

--- a/src/instaparse/gll.clj
+++ b/src/instaparse/gll.clj
@@ -111,10 +111,10 @@
   (binding [*out* writer]
     (fail/pprint-failure x)))
 
-(defn string->segment
-  "Converts a string to a Segment, which has fast subsequencing"
-  [s]
-  (Segment. s 0 (count s)))
+(defn text->segment
+  "Converts text to a Segment, which has fast subsequencing"
+  [^CharSequence text]
+  (Segment. text 0 (count text)))
 
 ; The trampoline structure contains the grammar, text to parse, a stack and a nodes
 ; Also contains an atom to hold successes and one to hold index of failure point.
@@ -129,9 +129,9 @@
                   stack next-stack generation negative-listeners 
                   msg-cache nodes success failure])
 (defn make-tramp 
-  ([grammar text] (make-tramp grammar text (string->segment text) -1 nil))
+  ([grammar text] (make-tramp grammar text (text->segment text) -1 nil))
   ([grammar text segment] (make-tramp grammar text segment -1 nil))
-  ([grammar text fail-index node-builder] (make-tramp grammar text (string->segment text) fail-index node-builder))
+  ([grammar text fail-index node-builder] (make-tramp grammar text (text->segment text) fail-index node-builder))
   ([grammar text segment fail-index node-builder]
     (Tramp. grammar text segment
             fail-index node-builder

--- a/src/instaparse/repeat.clj
+++ b/src/instaparse/repeat.clj
@@ -118,18 +118,18 @@
                        (select-parse grammar initial-parser text segment end follow-ups)))))))
 
 (defn repeat-parse 
-  ([grammar initial-parser output-format text] (repeat-parse-no-tag grammar initial-parser text (gll/string->segment text)))
+  ([grammar initial-parser output-format text] (repeat-parse-no-tag grammar initial-parser text (gll/text->segment text)))
   ([grammar initial-parser output-format root-tag text]
     {:pre [(#{:hiccup :enlive} output-format)]} 
     (cond
       (= output-format :hiccup)
-      (repeat-parse-hiccup grammar initial-parser root-tag text (gll/string->segment text))
+      (repeat-parse-hiccup grammar initial-parser root-tag text (gll/text->segment text))
       (= output-format :enlive)
-      (repeat-parse-enlive grammar initial-parser root-tag text (gll/string->segment text)))))
+      (repeat-parse-enlive grammar initial-parser root-tag text (gll/text->segment text)))))
 
 (defn repeat-parse-with-header
   ([grammar header-parser repeating-parser output-format root-tag text]
-    (let [segment (gll/string->segment text)
+    (let [segment (gll/text->segment text)
           length (count text)
           header-results (parse-from-index grammar header-parser text segment 0)]
       (if (or (empty? header-results)

--- a/test/instaparse/core_test.clj
+++ b/test/instaparse/core_test.clj
@@ -339,6 +339,11 @@
      [:AB [:A "a" "a" "a" "a" "a"] [:B "b" "b" "b"]]
      [:AB [:A "a" "a" "a" "a"] [:B "b" "b"]]]
     
+    (as-and-bs (StringBuilder. "aaaaabbbaaaabb"))
+    [:S
+     [:AB [:A "a" "a" "a" "a" "a"] [:B "b" "b" "b"]]
+     [:AB [:A "a" "a" "a" "a"] [:B "b" "b"]]]
+    
     (as-and-bs "aaaaabbbaaaabb")
     (as-and-bs "aaaaabbbaaaabb" :optimize :memory)
     


### PR DESCRIPTION
Thanks for all the fun with parsing!

I'm using Instaparse to parse a text header from a file that may contain binary data after the header. My strategy is to read lines in from the file using line-seq and stop and parse after I've reached the last of the header lines. I'm accumulating the lines in a StringBuilder and I noticed that my instaparse parser failed when I asked it to operate on the StringBuilder (a CharSequence) directly. I was able to work around that by converting the StringBuilder to a String before parsing.

I remembered reading in the Instaparse source that Java regexes operate on CharSequences so I thought it would be cool if Instaparse parsers could do that too. I guessed that Instaparse wasn't far from being able to do that already based on the Segment implementation. That turned out to be correct.

Please consider accepting this change into Instaparse. If it needs some fixes before being acceptable, I'll be happy to work on that.

Thanks!