### PR TITLE
handle new StringReader arity in 1.7.0-alpha6

### DIFF
--- a/src/instaparse/cfg.clj
+++ b/src/instaparse/cfg.clj
@@ -156,7 +156,14 @@
 ;  (binding [*read-eval* false]
 ;    (read-string s)))
 
-(let [string-reader (clojure.lang.LispReader$StringReader.)]
+(defn wrap-reader [reader]
+  (try
+    (eval 'clojure.lang.LispReader$ConditionalReader)
+    (fn [r s] (reader r s {} (java.util.LinkedList.)))
+    (catch Exception e reader)))
+
+(let [string-reader (wrap-reader
+                      (clojure.lang.LispReader$StringReader.))]
   (defn safe-read-string
     "Expects a double-quote at the end of the string"
     [s]


### PR DESCRIPTION
CLJ-1424 changed the arity of LispReader$StringReader in order to
support reader conditionals. This patch checks, at load time, which
arity is available, and wraps its string-reader accordingly.

Fix #90

check is at load time so should be fast