### PR TITLE
Char range combinator

### DIFF
--- a/docs/ABNF.md
+++ b/docs/ABNF.md
@@ -163,9 +163,11 @@ LWSP is particularly quirky, defined to be either a space or tab character, or a
 The `instaparse.combinators` contains a few combinators that are not documented in the main tutorial, but are listed here because they are only relevant to ABNF grammars.
 
 <table>
-<tr><th>String syntax</th><th>Combinator</th><th>Mnemonic</th></tr>
-<tr><td>"abc" (as used in ABNF)</td><td>string-ci</td><td>string, case-insensitive</td></tr>
-<tr><td>3*5 (as used in ABNF)</td><td>rep</td><td>repetition</td></tr>
+<tr><th>String syntax</th><th>Combinator</th><th>Functionality</th></tr>
+<tr><td>"abc" (as used in ABNF)</td><td>(string-ci "abc")</td><td>string, case-insensitive</td></tr>
+<tr><td>3*5 (as used in ABNF)</td><td>(rep 3 5 parser)</td><td>repetition</td></tr>
+<tr><td>%d97</td><td>(unicode-char 97)</td><td>unicode code point</td></tr>
+<tr><td>%d97-122</td><td>(unicode-char 97 122)</td><td>unicode range</td></tr>
 </table>
 
 Finally, just as there exists an `ebnf` function in the combinators namespace that turns EBNF fragments into combinator-built data structures, there exists an `abnf` function which does the same for ABNF fragments.

--- a/src/instaparse/abnf.clj
+++ b/src/instaparse/abnf.clj
@@ -80,11 +80,6 @@ regexp = #\"#'[^'\\\\]*(?:\\\\.[^'\\\\]*)*'(?x) #Single-quoted regexp\"
        | #\"#\\\"[^\\\"\\\\]*(?:\\\\.[^\\\"\\\\]*)*\\\"(?x) #Double-quoted regexp\"
 ")
 
-(defn char-range
-  "Takes two codepoints and returns a combinator representing a range of characters."
-  [codepoint1 codepoint2]
-  (regexp (format "[\\x{%x}-\\x{%x}]" codepoint1 codepoint2))) 
-
 (defn get-char-combinator
   ([num1]
     (string (String. (Character/toChars num1))))

--- a/src/instaparse/abnf.clj
+++ b/src/instaparse/abnf.clj
@@ -81,14 +81,12 @@ regexp = #\"#'[^'\\\\]*(?:\\\\.[^'\\\\]*)*'(?x) #Single-quoted regexp\"
 ")
 
 (defn get-char-combinator
-  ([num1]
-    (string (String. (Character/toChars num1))))
-  ([num1 num2 & nums]
-    (let [v (vec (concat [num1 num2] nums))]
-      (if (= (v 1) "-")
-        (char-range (v 0) (v 2))
-        (apply cat (for [n v]
-                     (string (String. (Character/toChars n)))))))))
+  [& nums]
+  (cond
+    (= "-" (second nums)) (let [[lo _ hi] nums]
+                            (unicode-char lo hi))
+    :else (apply cat (for [n nums]
+                       (unicode-char n)))))
 
 (defn project
   "Restricts map to certain keys"

--- a/src/instaparse/cfg.clj
+++ b/src/instaparse/cfg.clj
@@ -235,7 +235,7 @@
   [parser]
   (case (:tag parser)
     :nt [(:keyword parser)]
-    (:string :string-ci :regexp :epsilon) []
+    (:string :string-ci :char :regexp :epsilon) []
     (:opt :plus :star :look :neg :rep) (recur (:parser parser))
     (:alt :cat) (mapcat seq-nt (:parsers parser))
     :ord (mapcat seq-nt 

--- a/src/instaparse/combinators.clj
+++ b/src/instaparse/combinators.clj
@@ -19,7 +19,7 @@
 (defclone cat c/cat)
 (defclone string c/string)
 (defclone string-ci c/string-ci)
-(defclone char-range c/char-range)
+(defclone unicode-char c/unicode-char)
 (defclone regexp c/regexp)
 (defclone nt c/nt)
 (defclone look c/look)

--- a/src/instaparse/combinators.clj
+++ b/src/instaparse/combinators.clj
@@ -19,6 +19,7 @@
 (defclone cat c/cat)
 (defclone string c/string)
 (defclone string-ci c/string-ci)
+(defclone char-range c/char-range)
 (defclone regexp c/regexp)
 (defclone nt c/nt)
 (defclone look c/look)

--- a/src/instaparse/combinators_source.clj
+++ b/src/instaparse/combinators_source.clj
@@ -65,6 +65,11 @@
   (if (= s "") Epsilon
     {:tag :string-ci :string s}))
 
+(defn char-range "Create a character-range terminal between two code points (inclusive)"
+  [lo hi]
+  (assert (<= lo hi) "Character range minimum must be less than or equal the maximum")
+  {:tag :char :lo lo :hi hi})
+
 (defn regexp "Create a regexp terminal out of regular expression r"
   [r]
   (if (= r "") Epsilon

--- a/src/instaparse/combinators_source.clj
+++ b/src/instaparse/combinators_source.clj
@@ -36,7 +36,7 @@
     :else {:tag :alt :parsers parsers}))
 
 (defn- ord2 [parser1 parser2]
-    {:tag :ord :parser1 parser1 :parser2 parser2})
+  {:tag :ord :parser1 parser1 :parser2 parser2})
 
 (defn ord "Ordered choice, i.e., parser1 / parser2"
   ([] Epsilon)
@@ -171,7 +171,3 @@
                                          ws-parser)
                                     :red (:red (modified-grammar start))))]
     (merge final-grammar grammar-ws)))
-  
-    
-
-    

--- a/src/instaparse/combinators_source.clj
+++ b/src/instaparse/combinators_source.clj
@@ -65,10 +65,13 @@
   (if (= s "") Epsilon
     {:tag :string-ci :string s}))
 
-(defn char-range "Create a character-range terminal between two code points (inclusive)"
-  [lo hi]
-  (assert (<= lo hi) "Character range minimum must be less than or equal the maximum")
-  {:tag :char :lo lo :hi hi})
+(defn unicode-char
+  "Matches a Unicode code point or a range of code points"
+  ([code-point]
+   (unicode-char code-point code-point)) ; represented the same internally
+  ([lo hi]
+   (assert (<= lo hi) "Character range minimum must be less than or equal the maximum")
+   {:tag :char :lo lo :hi hi}))
 
 (defn regexp "Create a regexp terminal out of regular expression r"
   [r]

--- a/src/instaparse/gll.clj
+++ b/src/instaparse/gll.clj
@@ -110,7 +110,7 @@
 (declare alt-parse cat-parse string-parse epsilon-parse non-terminal-parse
          opt-parse plus-parse star-parse regexp-parse lookahead-parse
          rep-parse negative-lookahead-parse ordered-alt-parse
-         string-case-insensitive-parse)
+         string-case-insensitive-parse char-range-parse)
 (defn -parse [parser index tramp]
   (log tramp (format "Initiating parse: %s at index %d (%s)"
                      (print/combinators->str parser) index
@@ -121,6 +121,7 @@
     :cat (cat-parse parser index tramp)
     :string (string-parse parser index tramp)
     :string-ci (string-case-insensitive-parse parser index tramp)
+    :char (char-range-parse parser index tramp)
     :epsilon (epsilon-parse parser index tramp)
     :opt (opt-parse parser index tramp)
     :plus (plus-parse parser index tramp)
@@ -134,7 +135,7 @@
 (declare alt-full-parse cat-full-parse string-full-parse epsilon-full-parse 
          non-terminal-full-parse opt-full-parse plus-full-parse star-full-parse
          rep-full-parse regexp-full-parse lookahead-full-parse ordered-alt-full-parse
-         string-case-insensitive-full-parse)
+         string-case-insensitive-full-parse char-range-full-parse)
 (defn -full-parse [parser index tramp]
   (log tramp (format "Initiating full parse: %s at index %d (%s)"
                (print/combinators->str parser) index
@@ -145,6 +146,7 @@
     :cat (cat-full-parse parser index tramp)
     :string (string-full-parse parser index tramp)
     :string-ci (string-case-insensitive-full-parse parser index tramp)
+    :char (char-range-full-parse parser index tramp)
     :epsilon (epsilon-full-parse parser index tramp)
     :opt (opt-full-parse parser index tramp)
     :plus (plus-full-parse parser index tramp)
@@ -612,6 +614,26 @@
       (success tramp [index this] string end)
       (fail tramp [index this] index
             {:tag :string :expecting string :full true}))))
+
+(defn char-range-parse
+  [this index tramp]
+  (let [lo (:lo this)
+        hi (:hi this)]
+    (if (<= hi 0xFFFF)
+      (let [^String text (:text tramp)
+            character (.charAt text index)]
+        (if (<= lo (int character) hi)
+          (success tramp [index this] (str character) (inc index))
+          (fail tramp [index this] index
+                {:tag :char :lo lo :hi hi})))
+      (let [^String text (:text tramp)
+            code-point (Character/codePointAt text index)
+            char-string (Character/toChars code-point)]
+        (if (<= lo code-point hi)
+          (success tramp [index this] (apply str (Character/toChars code-point))
+                   (+ index (count char-string)))
+          (fail tramp [index this] index
+                {:tag :char :lo lo :hi hi}))))))
 
 (defn re-match-at-front [regexp text]
   (let [^java.util.regex.Matcher matcher (re-matcher regexp text)

--- a/src/instaparse/gll.clj
+++ b/src/instaparse/gll.clj
@@ -617,7 +617,9 @@
 
 (defn char-range-expecting
   [lo hi]
-  (format "%%x%04x-%04x" lo hi))
+  (if (= lo hi)
+    (format "%%x%04x" lo)
+    (format "%%x%04x-%04x" lo hi)))
 
 (defn char-range-parse
   [this index tramp]
@@ -630,7 +632,7 @@
           (success tramp [index this] (str character) (inc index))
           (fail tramp [index this] index
                 {:tag :char :expecting (char-range-expecting lo hi)})))
-      (let [code-point (Character/codePointAt text index)
+      (let [code-point (Character/codePointAt text (int index))
             char-string (String. (Character/toChars code-point))]
         (if (<= lo code-point hi)
           (success tramp [index this] char-string
@@ -642,18 +644,18 @@
   [this index tramp]
   (let [lo (:lo this)
         hi (:hi this)
-        ^String text (:text tramp)
+        text (:text tramp)
         end (count text)]
     (if (<= hi 0xFFFF)
-      (let [character (.charAt text index)]
+      (let [character (.charAt ^String text index)]
         (if (and (= (inc index) end) (<= lo (int character) hi))
           (success tramp [index this] (str character) end)
           (fail tramp [index this] index
                 {:tag :char :expecting (char-range-expecting lo hi) :full true})))
-      (let [code-point (Character/codePointAt text index)
+      (let [code-point (Character/codePointAt ^String text (int index))
             char-string (String. (Character/toChars code-point))]
         (if (and (= (+ index (count char-string)) end) (<= lo code-point hi))
-          (success tramp [index this] end)
+          (success tramp [index this] char-string end)
           (fail tramp [index this] index
                 {:tag :char :expecting (char-range-expecting lo hi) :full true}))))))
 

--- a/src/instaparse/gll.clj
+++ b/src/instaparse/gll.clj
@@ -626,19 +626,21 @@
   (let [lo (:lo this)
         hi (:hi this)
         ^String text (:text tramp)]
-    (if (<= hi 0xFFFF)
-      (let [character (.charAt text index)]
-        (if (<= lo (int character) hi)
-          (success tramp [index this] (str character) (inc index))
-          (fail tramp [index this] index
-                {:tag :char :expecting (char-range-expecting lo hi)})))
-      (let [code-point (Character/codePointAt text (int index))
-            char-string (String. (Character/toChars code-point))]
-        (if (<= lo code-point hi)
-          (success tramp [index this] char-string
-                   (+ index (count char-string)))
-          (fail tramp [index this] index
-                {:tag :char :expecting (char-range-expecting lo hi)}))))))
+    (cond
+      (>= index (count text)) (fail tramp [index this] index
+                                    {:tag :char :expecting (char-range-expecting lo hi)})
+      (<= hi 0xFFFF) (let [character (.charAt text index)]
+                       (if (<= lo (int character) hi)
+                         (success tramp [index this] (str character) (inc index))
+                         (fail tramp [index this] index
+                               {:tag :char :expecting (char-range-expecting lo hi)})))
+      :else (let [code-point (Character/codePointAt text (int index))
+                  char-string (String. (Character/toChars code-point))]
+              (if (<= lo code-point hi)
+                (success tramp [index this] char-string
+                         (+ index (count char-string)))
+                (fail tramp [index this] index
+                      {:tag :char :expecting (char-range-expecting lo hi)}))))))
 
 (defn char-range-full-parse
   [this index tramp]
@@ -646,18 +648,20 @@
         hi (:hi this)
         text (:text tramp)
         end (count text)]
-    (if (<= hi 0xFFFF)
-      (let [character (.charAt ^String text index)]
-        (if (and (= (inc index) end) (<= lo (int character) hi))
-          (success tramp [index this] (str character) end)
-          (fail tramp [index this] index
-                {:tag :char :expecting (char-range-expecting lo hi) :full true})))
-      (let [code-point (Character/codePointAt ^String text (int index))
-            char-string (String. (Character/toChars code-point))]
-        (if (and (= (+ index (count char-string)) end) (<= lo code-point hi))
-          (success tramp [index this] char-string end)
-          (fail tramp [index this] index
-                {:tag :char :expecting (char-range-expecting lo hi) :full true}))))))
+    (cond
+      (>= index (count text)) (fail tramp [index this] index
+                                    {:tag :char :expecting (char-range-expecting lo hi)})
+      (<= hi 0xFFFF) (let [character (.charAt ^String text index)]
+                       (if (and (= (inc index) end) (<= lo (int character) hi))
+                         (success tramp [index this] (str character) end)
+                         (fail tramp [index this] index
+                               {:tag :char :expecting (char-range-expecting lo hi) :full true})))
+      :else (let [code-point (Character/codePointAt ^String text (int index))
+                  char-string (String. (Character/toChars code-point))]
+              (if (and (= (+ index (count char-string)) end) (<= lo code-point hi))
+                (success tramp [index this] char-string end)
+                (fail tramp [index this] index
+                      {:tag :char :expecting (char-range-expecting lo hi) :full true}))))))
 
 (defn re-match-at-front [regexp text]
   (let [^java.util.regex.Matcher matcher (re-matcher regexp text)

--- a/src/instaparse/print.clj
+++ b/src/instaparse/print.clj
@@ -29,6 +29,11 @@
     (str "#\"" (str r) "\"")
     #"[\s]" regexp-replace))
 
+(defn char-range->str [{:keys [lo hi]}]
+  (if (= lo hi)
+    (format "%%x%04x" lo)
+    (format "%%x%04x-%04x" lo hi)))
+
 (defn combinators->str
   "Stringifies a parser built from combinators"
   ([p] (combinators->str p false))
@@ -52,7 +57,7 @@
         :cat (str/join " " (map (partial paren-for-tags #{:alt :ord} hidden?) parsers))
         :string (with-out-str (pr (:string p)))
         :string-ci (with-out-str (pr (:string p)))
-        :char (format "%%x%04x-%04x" (:lo p) (:hi p))
+        :char (char-range->str p)
         :regexp (regexp->str (:regexp p))
         :nt (subs (str (:keyword p)) 1)
         :look (str "&" (paren-for-compound hidden? parser))

--- a/src/instaparse/print.clj
+++ b/src/instaparse/print.clj
@@ -52,6 +52,7 @@
         :cat (str/join " " (map (partial paren-for-tags #{:alt :ord} hidden?) parsers))
         :string (with-out-str (pr (:string p)))
         :string-ci (with-out-str (pr (:string p)))
+        :char (format "%%x%04x-%04x" (:lo p) (:hi p))
         :regexp (regexp->str (:regexp p))
         :nt (subs (str (:keyword p)) 1)
         :look (str "&" (paren-for-compound hidden? parser))

--- a/test/instaparse/abnf_test.clj
+++ b/test/instaparse/abnf_test.clj
@@ -132,3 +132,38 @@ to test the lookahead"
     (if (<= 42 i 91)
       (is (not (instance? instaparse.gll.Failure (regex-chars (str c)))))
       (is (instance? instaparse.gll.Failure (regex-chars (str c)))))))
+
+(deftest unicode-test
+  (let [poop "\uD83D\uDCA9"]  ; U+1F4A9 PILE OF POO
+    (let [parser1 (parser "S = %x1F4A9"
+                          :input-format :abnf)]
+      (are [x y] (= x y)
+           (parses parser1 poop) [[:S poop]])
+      (are [x] (instance? instaparse.gll.Failure x)
+           (parser1 (str poop poop))
+           (parser1 (str (first poop)))
+           ;; shouldn't work on the surrogate characters individually
+           (parser1 (str (second poop)))))
+    (let [parser2 (parser "S = %x1F4A8-1F4A9"
+                          :input-format :abnf)]
+      (are [x y] (= x y)
+           (parses parser2 poop) [[:S poop]])
+      (are [x] (instance? instaparse.gll.Failure x)
+           (parser2 (str poop poop))
+           (parser2 (str (first poop)))
+           (parser2 (str (second poop)))))
+    (let [parser3 (parser "S = %x1F4A9.1F4A9.1F4A9"
+                          :input-format :abnf)]
+      (are [x y] (= x y)
+           (parses parser3 (str poop poop poop)) [[:S poop poop poop]])
+      (are [x] (instance? instaparse.gll.Failure x)
+           (parser3 (str poop))))
+    ;; it would be cool if EBNF supported unicode in a parser spec
+    ;; (ABNF doesn't allow that though)
+    (let [parser4 (parser (str "S = '" poop "'*"))]
+      (are [x y] (= x y)
+           (parses parser4 (str poop poop poop)) [[:S poop poop poop]])
+      (are [x] (instance? instaparse.gll.Failure x)
+           (parser4 (str (first poop)))
+           (parser4 (str (second poop)))
+           (parser4 (str poop poop (first poop)))))))


### PR DESCRIPTION
Currently, ABNF code point ranges (e.g. `%x92-94`) translate to a regular expression like `#'[\x{92}-\x{94}]'`. But this is not portable to ClojureScript, because JavaScript does not support this regular expression syntax (it was introduced later in ECMAScript 6). In fact (as far as I know) it is impossible to match a *range* of Unicode code points without pulling in third-party utilities. [This](https://mathiasbynens.be/notes/javascript-unicode#regex) article explains JavaScript's limitations in more depth.

This PR introduces a new approach that does not seem to affect performance at all (neither gain nor loss) is more easily translatable to ClojureScript.

There is now a "unicode-char" combinator that will parse a single character (or a UTF-16 surrogate pair) given a range of Unicode code points. The non-terminal parser uses the `Character/codePointAt` method to extract the Unicode code point from the text at the given index, and checks it is between the range. This behavior **is** translatable to cljs, because Closure has `goog.i18n.uChar/getCodePointAround` which has the same functionality.