### PR TITLE
Make ebnf / abnf combinator's "rules or parser" flexibility more robust

### DIFF
--- a/src/instaparse/abnf.clj
+++ b/src/instaparse/abnf.clj
@@ -77,7 +77,7 @@ NUM = DIGIT+;
 opt-whitespace = #'\\s*(?:;.*?(?:\\u000D?\\u000A\\s*|$))*(?x) # optional whitespace or comments';
 whitespace = #'\\s+(?:;.*?\\u000D?\\u000A\\s*)*(?x) # whitespace or comments';
 regexp = #\"#'[^'\\\\]*(?:\\\\.[^'\\\\]*)*'(?x) #Single-quoted regexp\"
-       | #\"#\\\"[^\\\"\\\\]*(?:\\\\.[^\\\"\\\\]*)*\\\"(?x) #Double-quoted regexp\"
+       | #\"#\\\"[^\\\"\\\\]*(?:\\\\.[^\\\"\\\\]*)*\\\"(?x) #Double-quoted regexp\";
 
 (* extra entrypoint to be used by the abnf combinator *)
 <rules-or-parser> = rulelist | alternation;

--- a/src/instaparse/abnf.clj
+++ b/src/instaparse/abnf.clj
@@ -78,6 +78,9 @@ opt-whitespace = #'\\s*(?:;.*?(?:\\u000D?\\u000A\\s*|$))*(?x) # optional whitesp
 whitespace = #'\\s+(?:;.*?\\u000D?\\u000A\\s*)*(?x) # whitespace or comments';
 regexp = #\"#'[^'\\\\]*(?:\\\\.[^'\\\\]*)*'(?x) #Single-quoted regexp\"
        | #\"#\\\"[^\\\"\\\\]*(?:\\\\.[^\\\"\\\\]*)*\\\"(?x) #Double-quoted regexp\"
+
+(* extra entrypoint to be used by the abnf combinator *)
+<rules-or-parser> = rulelist | alternation;
 ")
 
 (defn get-char-combinator
@@ -188,18 +191,15 @@ If you give it the right-hand side of a rule, it will return the combinator equi
 If you give it a series of rules, it will give you back a grammar map.   
 Useful for combining with other combinators."
   [spec]
-  (if (re-find #"=" spec)
-    (let [rule-tree (gll/parse abnf-parser :rulelist spec false)]
-      (if (instance? instaparse.gll.Failure rule-tree)
-        (throw (RuntimeException. (str "Error parsing grammar specification:\n"
-                                       (with-out-str (println rule-tree)))))
-        (rules->grammar-map (t/transform abnf-transformer rule-tree))))      
-    
-    (let [rhs-tree (gll/parse abnf-parser :alternation spec false)]
-      (if (instance? instaparse.gll.Failure rhs-tree)
-        (throw (RuntimeException. (str "Error parsing grammar specification:\n"
-                                       (with-out-str (println rhs-tree)))))        
-        (t/transform abnf-transformer rhs-tree)))))
+  (let [tree (gll/parse abnf-parser :rules-or-parser spec false)]
+    (cond
+      (instance? instaparse.gll.Failure tree)
+      (throw (RuntimeException. (str "Error parsing grammar specification:\n"
+                                     (with-out-str (println tree)))))
+      (= :alternation (ffirst tree))
+      (t/transform abnf-transformer (first tree))
+
+      :else (rules->grammar-map (t/transform abnf-transformer tree)))))
 
 (defn build-parser [spec output-format]
   (let [rule-tree (gll/parse abnf-parser :rulelist spec false)]

--- a/src/instaparse/cfg.clj
+++ b/src/instaparse/cfg.clj
@@ -127,7 +127,9 @@
                                  (nt :plus)
                                  (nt :paren)
                                  (nt :hide)
-                                 (nt :epsilon)))}))
+                                 (nt :epsilon)))
+     ;; extra entrypoint to be used by the ebnf combinator
+     :rules-or-parser (hide-tag (alt (nt :rules) (nt :alt-or-ord)))}))
 
 ; Internally, we're converting the grammar into a hiccup parse tree
 ; Here's how you extract the relevant information
@@ -276,14 +278,12 @@ If you give it the right-hand side of a rule, it will return the combinator equi
 If you give it a series of rules, it will give you back a grammar map.   
 Useful for combining with other combinators."
   [spec]
-  (if (re-find #"[:=]" spec)    
-    (let [rules (parse cfg :rules spec false)]
-      (if (instance? instaparse.gll.Failure rules)
-        (throw (RuntimeException. (str "Error parsing grammar specification:\n"
-                                       (with-out-str (println rules)))))    
-        (into {} (map build-rule rules))))
-    (let [rhs (parse cfg :alt-or-ord spec false)]
-      (if (instance? instaparse.gll.Failure rhs)
-        (throw (RuntimeException. (str "Error parsing grammar specification:\n"
-                                       (with-out-str (println rhs)))))          
-        (build-rule (first rhs))))))      
+  (let [rules (parse cfg :rules-or-parser spec false)]
+    (cond
+      (instance? instaparse.gll.Failure rules)
+      (throw (RuntimeException. (str "Error parsing grammar specification:\n"
+                                     (with-out-str (println rules)))))
+      (= :rule (ffirst rules))
+      (into {} (map build-rule rules))
+
+      :else (build-rule (first rules)))))

--- a/test/instaparse/abnf_test.clj
+++ b/test/instaparse/abnf_test.clj
@@ -1,6 +1,7 @@
 (ns instaparse.abnf-test
   (:use clojure.test)
-  (:use instaparse.core))
+  (:use instaparse.core)
+  (:require [instaparse.combinators :refer [abnf]]))
 
 (deftest abnf-uri
   (let [uri-parser (binding [instaparse.abnf/*case-insensitive* true]
@@ -167,3 +168,15 @@ to test the lookahead"
            (parser4 (str (first poop)))
            (parser4 (str (second poop)))
            (parser4 (str poop poop (first poop)))))))
+
+(deftest abnf-combinator-test
+  (let [p (parser (merge
+                   {:S (abnf "A / B")}
+                   (abnf "<A> = 1*'a'")
+                   {:B (abnf "'='")})
+                  :start :S)]
+    (are [x y] (= y x)
+      (p "aAaa")
+      [:S "a" "a" "a" "a"]
+      (p "=")
+      [:S [:B "="]])))

--- a/test/instaparse/core_test.clj
+++ b/test/instaparse/core_test.clj
@@ -244,6 +244,15 @@
       {:B (ebnf "'b'+")})
     :start :S))
 
+(def tricky-ebnf-build
+  "https://github.com/Engelberg/instaparse/issues/107"
+  (insta/parser
+    (merge
+      {:S (alt (nt :A) (nt :B))}
+      (ebnf "<A> = '='*")
+      {:B (ebnf "'b' '='")})
+    :start :S))
+
 (defn spans [t]
   (if (sequential? t)
     (cons (insta/span t) (map spans (next t)))
@@ -552,7 +561,13 @@
     [:S [:B "b" "b" "b" "b" "b"]]
     
     (combo-build-example "bbbbb")
-    (combo-build-example "bbbbb" :optimize :memory)    
+    (combo-build-example "bbbbb" :optimize :memory)
+
+    (tricky-ebnf-build "===")
+    [:S "=" "=" "="]
+
+    (tricky-ebnf-build "b=")
+    [:S [:B "b" "="]]
     
     ((insta/parser "S = ('a'?)+") "")
     [:S]


### PR DESCRIPTION
Desired functionality: `ebnf` and `abnf` combinators can either take a rules spec (`x = 'y' | 'z'`) or just a right-hand side parser (`'y' | 'z'`).

Mark's first approach: Try parsing it as a set of rules, and if it fails, try parsing it as a right-hand parser.

Problem with this approach: Possibly errors were unclear for invalid input?

Mark's second approach: Check spec for `=` or `:` character to determine whether to parse it as a set of rules or a single parser. Then parse it with the EBNF grammar with the starting rule set as either `rules` (for one or more rules) or `alt-or-ord` (for right-hand side). Similar approach for ABNF.

Problem with this approach: `'='` should be a valid right-hand side (i.e. the parser for the character `=`). However, that strategy breaks for this input, because the `=` character sends it down the wrong path (trying to parse it as a set of rules).

Alex's new, proposed approach: Add a new non-terminal to the EBNF grammar (called `rules-or-parser`) which is simply the alternation of `rules` and `alt-or-ord`. The ebnf combinator parses the spec with `rules-or-parser` set as the starting rule, then checks the hiccup output to determine what type of spec was passed in. Similar approach for ABNF.