### PR TITLE
improve error for parsing from a nonexistent lhs

### DIFF
--- a/src/instaparse/gll.clj
+++ b/src/instaparse/gll.clj
@@ -872,6 +872,11 @@
 ;; Parsing functions
 
 (defn start-parser [tramp parser partial?]
+  (let [starting-prod (:keyword parser)
+        known-productions (into #{} (map first (:grammar tramp)))]
+    (when (not (known-productions starting-prod))
+      (throw (IllegalArgumentException.
+               (str "Nonexistent starting production: " starting-prod)))))
   (if partial?
     (push-listener tramp [0 parser] (TopListener tramp))
     (push-full-listener tramp [0 parser] (TopListener tramp))))

--- a/test/instaparse/core_test.clj
+++ b/test/instaparse/core_test.clj
@@ -684,6 +684,15 @@
     15
     ))    
 
+(deftest error-nonexistent-starting-production
+  (let [parser (insta/parser "cat = 'mjau'")]
+    (is (thrown-with-msg?
+          IllegalArgumentException
+          #"Nonexistent starting production: :dog"
+          (insta/parse parser "mjau" :start :dog)))
+    (is (= [:cat "mjau"]
+           (insta/parse parser "mjau" :start :cat)))))
+
 (defn round-trip [parser]
   (insta/parser (prn-str parser)))
 


### PR DESCRIPTION
I ran into this when I renamed a production rule. There was previously no specific error message, it just kept going until it hit a not-very-helpful exception in the guts of the parsing code.
