### PR TITLE
Fix rep listener

### DIFF
--- a/test/instaparse/abnf_test.clj
+++ b/test/instaparse/abnf_test.clj
@@ -101,25 +101,28 @@ to test the lookahead"
 (def reps
   "Testing the different kinds of repetitions"
   (parser
-    "S = A B C D E
+    "S = A B C D E FG
      A = *'a'
      B = 2*'b'
      C = *2'c'
      D = 2'd'
-     E = 2*4'e'"
+     E = 2*4'e'
+     FG = 2('f' 'g')"
     :input-format :abnf))
 
 (deftest rep-test
   (are [x] (not (instance? instaparse.gll.Failure x))
-       (reps "aabbccddee")
-       (reps "bbbbbbddeeee")
-       (reps "bbcddee")))
+       (reps "aabbccddeefgfg")
+       (reps "bbbbbbddeeeefgfg")
+       (reps "bbcddeefgfg")))
 
 (deftest rep-test-errors
   (are [x] (instance? instaparse.gll.Failure x)
        (reps "")
-       (reps "bccddee")
-       (reps "aaaabbbbcccddee")))
+       (reps "bccddeefgfg")
+       (reps "aaaabbbbcccddeefgfg")
+       (reps "aabbccddeefg")
+       (reps "aabbccddeeffgg")))
 
 (def regex-chars
   "Testing %d42-91. The boundary chars are \"*\" and \"[\", which normally aren't allowed in a regex."


### PR DESCRIPTION
(Fixes #134)

Bug:
A repetition parser wrapped around a concatenation does not behave properly. It is incorrectly searching for between `m` and `n` *total tokens* parsed instead of between `m` and `n` *complete results* of the sub-parse. For example, `(rep 2 2 (cat (string "a") (string "b")))` is looking for two tokens, therefore only the string `"ab"` will satisfy it, whereas the string `"abab"` should be what satisfies it.

Solution:
In `RepListener` and `RepFullListener`, counting `results-so-far` is an inaccurate indicator of how many times the sub-parser returns a success, so now we will actually hold onto the number of times the sub-parser is successful, and increment it each iteration.