### PR TITLE
Fix bug where transform fails on afs with top level string

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,15 +3,16 @@
   :url "https://github.com/Engelberg/instaparse"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]]
   :profiles {:dev {:dependencies 
                    [[org.clojure/tools.trace "0.7.5"]
                     [criterium "0.3.1"]
                     [rhizome "0.2.5"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
-             :1.7 {:dependencies [[org.clojure/clojure "1.7.0-RC2"]]}}
-  :aliases {"test-all" ["with-profile" "+1.5:+1.6:+1.7" "test"]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
+             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}}
+  :aliases {"test-all" ["with-profile" "+1.5:+1.6:+1.7:+1.8" "test"]}
   :test-paths ["test"]
   :target-path "target"
   :scm {:name "git"

--- a/src/instaparse/transform.clj
+++ b/src/instaparse/transform.clj
@@ -53,6 +53,10 @@ something that can have a metamap attached."
   [transform-map parse-tree]
   ; Detect what kind of tree this is
   (cond
+    (string? parse-tree)
+    ; This is a leaf of the tree that should pass through unchanged
+    parse-tree
+
     (and (map? parse-tree) (:tag parse-tree))
     ; This is an enlive tree-seq
     (enlive-transform transform-map parse-tree)

--- a/test/instaparse/core_test.clj
+++ b/test/instaparse/core_test.clj
@@ -682,6 +682,11 @@
     
     (insta/transform {:ADD +} [:ADD 10 5])
     15
+
+    (->> "a"
+         ((insta/parser "<S> = 'a'"))
+         (insta/transform {}))
+    '("a")
     ))    
 
 (defn round-trip [parser]


### PR DESCRIPTION
Fixes this bug, found by @seylerius: 
```clojure
user> (insta/transform {} ((insta/parser "<S> = 'a'+") "a"))
IllegalArgumentException Invalid parse-tree, not recognized as either enlive or hiccup format.  instaparse.transform/transform (transform.clj:55)
```