### PR TITLE
ABNF mode can be overridden to use case-sensitive strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Instaparse Change Log
 
+## Unreleased
+
+### Enhancements
+
+* ABNF parsers' string case-insensitivity can now be disabled by setting `:string-ci false`.
+
 ## 1.4.7
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -976,10 +976,11 @@ Instaparse's primary input format is based on EBNF syntax, but an alternative in
 
 ### String case sensitivity
 
-One interesting difference between EBNF and ABNF grammars is that in EBNF, string terminals are case-sensitive whereas in ABNF, all string terminals are case-*in*sensitive.  If you like ABNF's case-insensitive approach, but want to use Instaparse's somewhat richer EBNF syntax, there are a couple options available to you.
+One notable difference between EBNF and ABNF notations is that in EBNF, string terminals are case-sensitive, whereas in ABNF, string terminals are traditionally case-*in*sensitive.
 
-If you want *all* of the string terminals in your Instaparse EBNF grammar to be case-insensitive, the simplest solution is to use the `:string-ci true` keyword argument when calling `insta/parser` to make the strings case-insensitive:
+Instaparse follows the respective behaviors of the two notations by default, but in both cases, the case-sensitivity is overridable with the `:string-ci` flag, which states for sure whether all string terminals in the grammar are case-insensitive.
 
+	;; EBNF, case-sensitive
 	=> ((insta/parser "S = 'a'+") "AaaAaa")
 	Parse error at line 1, column 1:
 	AaaAaa
@@ -987,10 +988,19 @@ If you want *all* of the string terminals in your Instaparse EBNF grammar to be 
 	Expected:
 	"a"
 
+	;; EBNF, case-insensitive
 	=> ((insta/parser "S = 'a'+" :string-ci true) "AaaAaa")
 	[:S "a" "a" "a" "a" "a" "a"]
 
-On the other hand, if you want to cherry-pick certain string tokens to be case-insensitive, simply convert your string tokens into case-insensitive regexes, for example, replacing the string `'select'` with `#'(?i)select'`.
+	;; ABNF, case-sensitive (not the default!)
+	=> ((insta/parser "S = 'a'+" :input-format :abnf :string-ci false) "AaaAaa")
+	Parse error at line 1, column 1:
+	AaaAaa
+	^
+	Expected:
+	"a"
+
+On the other hand, if you want to mix and match case-sensitive and case-insensitive strings, you can convert strings to regexes, such as `#'I am case sensitive'` or `#'(?i)I am case in-sensitive'`.
 
 ### Serialization
 

--- a/src/instaparse/abnf.cljc
+++ b/src/instaparse/abnf.cljc
@@ -221,8 +221,8 @@ regexp = #\"#'[^'\\\\]*(?:\\\\.[^'\\\\]*)*'\"
    :neg neg
    :regexp (comp regexp cfg/process-regexp)
    :char-val (fn [& cs]
-               ; case insensitive string
-               (string-ci (apply str cs)))
+               ((if cfg/*case-insensitive-literals* string-ci string)
+                (apply str cs)))
    :bin-char (fn [& cs]
                (parse-int (apply str cs) 2))
    :dec-char (fn [& cs]

--- a/src/instaparse/abnf.cljc
+++ b/src/instaparse/abnf.cljc
@@ -245,15 +245,16 @@ If you give it a series of rules, it will give you back a grammar map.
 Useful for combining with other combinators."
   [spec]
   (let [tree (gll/parse abnf-parser :rules-or-parser spec false)]
-    (cond
-      (instance? instaparse.gll.Failure tree)
-      (throw-runtime-exception
-        "Error parsing grammar specification:\n"
-        (with-out-str (println tree)))
-      (= :alternation (ffirst tree))
-      (t/transform abnf-transformer (first tree))
+    (binding [cfg/*case-insensitive-literals* true]
+      (cond
+        (instance? instaparse.gll.Failure tree)
+        (throw-runtime-exception
+          "Error parsing grammar specification:\n"
+          (with-out-str (println tree)))
+        (= :alternation (ffirst tree))
+        (t/transform abnf-transformer (first tree))
 
-      :else (rules->grammar-map (t/transform abnf-transformer tree)))))
+        :else (rules->grammar-map (t/transform abnf-transformer tree))))))
 
 (defn build-parser [spec output-format]
   (let [rule-tree (gll/parse abnf-parser :rulelist spec false)]

--- a/src/instaparse/core.cljc
+++ b/src/instaparse/core.cljc
@@ -206,13 +206,15 @@
                  (contains? ws-parser :grammar)
                  (contains? ws-parser :start-production))))]}
   (let [input-format (get options :input-format *default-input-format*)
-        build-parser (case input-format 
-                       :abnf abnf/build-parser
-                       :ebnf (if (get options :string-ci)
-                               (fn [spec output-format]
-                                 (binding [cfg/*case-insensitive-literals* true]
-                                   (cfg/build-parser spec output-format)))
-                               cfg/build-parser))
+        build-parser
+        (fn [spec output-format]
+          (case input-format
+            :abnf (binding [cfg/*case-insensitive-literals*
+                            (boolean (:string-ci options true))]
+                    (abnf/build-parser spec output-format))
+            :ebnf (binding [cfg/*case-insensitive-literals*
+                            (boolean (:string-ci options false))]
+                    (cfg/build-parser spec output-format))))
         output-format (get options :output-format *default-output-format*)
         start (get options :start nil)
 

--- a/test/instaparse/abnf_test.cljc
+++ b/test/instaparse/abnf_test.cljc
@@ -219,3 +219,25 @@ to test the lookahead"
       [:S "a" "a" "a" "a"]
       (p "=")
       [:S [:B "="]])))
+
+(defn output-matches?
+  [expected actual]
+  (if (= :fail expected)
+    (instance? instaparse.gll.Failure actual)
+    (= expected actual)))
+
+(deftest string-ci-test
+  (are [parser input expected] (output-matches? expected (parser input))
+    (parser "S = 'Hi'" :input-format :ebnf) "Hi" [:S "Hi"]
+    (parser "S = 'Hi'" :input-format :ebnf) "hi" :fail
+    (parser "S = 'Hi'" :input-format :ebnf :string-ci false) "Hi" [:S "Hi"]
+    (parser "S = 'Hi'" :input-format :ebnf :string-ci false) "hi" :fail
+    (parser "S = 'Hi'" :input-format :ebnf :string-ci true) "Hi" [:S "Hi"]
+    (parser "S = 'Hi'" :input-format :ebnf :string-ci true) "hi" [:S "Hi"]
+
+    (parser "S = 'Hi'" :input-format :abnf) "Hi" [:S "Hi"]
+    (parser "S = 'Hi'" :input-format :abnf) "hi" [:S "Hi"]
+    (parser "S = 'Hi'" :input-format :abnf :string-ci false) "Hi" [:S "Hi"]
+    (parser "S = 'Hi'" :input-format :abnf :string-ci false) "hi" :fail
+    (parser "S = 'Hi'" :input-format :abnf :string-ci true) "Hi" [:S "Hi"]
+    (parser "S = 'Hi'" :input-format :abnf :string-ci true) "hi" [:S "Hi"]))


### PR DESCRIPTION
ABNF grammars traditionally parse strings case-insensitively, but for special cases where that is undesirable, users can now set `:string-ci false` to override the default behavior.

Fixes #158 