### PR TITLE
switch to tools.reader for clojurescript 1.9.854+

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,8 @@
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [org.clojure/clojurescript "1.8.34"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0-alpha16"]
-                                  [org.clojure/clojurescript "1.9.562"]]}}
+                                  [org.clojure/clojurescript "1.9.854"]
+                                  [org.clojure/tools.reader "1.0.3"]]}}
   :aliases {"test-all" ["with-profile" "+1.5:+1.6:+1.7:+1.8:+1.9" "test"]
             "test-cljs" ["cljsbuild" "test" "unit-tests"]
             "test-cljs-all" ["with-profile" "+1.7:+1.8:+1.9" "do" "clean," "test-cljs"]}

--- a/src/instaparse/cfg.cljc
+++ b/src/instaparse/cfg.cljc
@@ -9,7 +9,8 @@
             [instaparse.util :refer [throw-illegal-argument-exception
                                      throw-runtime-exception]]
             [clojure.string :as str]
-            #?(:cljs [cljs.reader :as reader])))
+            #?(:cljs [cljs.tools.reader :as reader])
+            #?(:cljs [cljs.tools.reader.reader-types :as readers])))
 
 (def ^:dynamic *case-insensitive-literals*
   "When true all string literal terminals in built grammar will be treated as case insensitive"
@@ -188,7 +189,7 @@
 
    :cljs
    (defn safe-read-string [s]
-     (reader/read-string* (reader/push-back-reader s) nil)))
+     (reader/read-string* (readers/string-push-back-reader s) nil nil nil)))
 
 ; I think re-pattern is sufficient, but here's how to do it without.
 ;(let [regexp-reader (clojure.lang.LispReader$RegexReader.)]


### PR DESCRIPTION
[CLJS-1800](https://github.com/clojure/clojurescript/commit/07ee2250af02b25f232111890c0f40f23150768d) moves reading  to tools.reader. 