### PR TITLE
Get rid of reflection warnings

### DIFF
--- a/src/instaparse/abnf.cljc
+++ b/src/instaparse/abnf.cljc
@@ -106,7 +106,7 @@ regexp = #\"#'[^'\\\\]*(?:\\\\.[^'\\\\]*)*'\"
 #?(:clj
    (defmacro precompile-cljs-grammar
      []
-     (let [combinators (red/apply-standard-reductions 
+     (let [combinators (red/apply-standard-reductions
                          :hiccup (cfg/ebnf (str abnf-grammar-common
                                                 abnf-grammar-cljs-only)))]
        (walk/postwalk
@@ -125,7 +125,7 @@ regexp = #\"#'[^'\\\\]*(?:\\\\.[^'\\\\]*)*'\"
          combinators))))
 
 #?(:clj
-   (def abnf-parser (red/apply-standard-reductions 
+   (def abnf-parser (red/apply-standard-reductions
                       :hiccup (cfg/ebnf (str abnf-grammar-common
                                              abnf-grammar-clj-only))))
    :cljs
@@ -146,7 +146,7 @@ regexp = #\"#'[^'\\\\]*(?:\\\\.[^'\\\\]*)*'\"
         (for [k ks
               :when (contains? m k)]
           [k (m k)])))
-          
+
 (defn merge-core
   "Merges abnf-core map in with parsed grammar map"
   [grammar-map]
@@ -178,9 +178,9 @@ regexp = #\"#'[^'\\\\]*(?:\\\\.[^'\\\\]*)*'\"
      ([string radix] (Integer/parseInt string radix)))
    :cljs
    (def parse-int js/parseInt))
-        
+
 (def abnf-transformer
-  {   
+  {
    :rule hash-map
    :hide-tag-rule (fn [tag rule] {tag (hide-tag rule)})
    :rulename-left #(if *case-insensitive*
@@ -201,8 +201,8 @@ regexp = #\"#'[^'\\\\]*(?:\\\\.[^'\\\\]*)*'\"
                    (= (first items) "*") {:high (second items)}     ; *x
                    :else {:low (first items)})                      ; x*
                3 {:low (first items), :high (nth items 2)}))        ; x*y
-                 
-   :repetition (fn 
+
+   :repetition (fn
                  ([repeat element]
                    (cond
                      (empty? repeat) (star element)
@@ -240,7 +240,7 @@ regexp = #\"#'[^'\\\\]*(?:\\\\.[^'\\\\]*)*'\"
 (defn abnf
   "Takes an ABNF grammar specification string and returns the combinator version.
 If you give it the right-hand side of a rule, it will return the combinator equivalent.
-If you give it a series of rules, it will give you back a grammar map.   
+If you give it a series of rules, it will give you back a grammar map.
 Useful for combining with other combinators."
   [spec & {:as opts}]
   (binding [cfg/*case-insensitive-literals* (:string-ci opts :default)]
@@ -263,7 +263,7 @@ Useful for combining with other combinators."
         (with-out-str (println rule-tree)))
       (let [rules (t/transform abnf-transformer rule-tree)
             grammar-map (rules->grammar-map rules)
-            start-production (first (first (first rules)))] 
+            start-production (first (first (first rules)))]
         {:grammar (cfg/check-grammar (red/apply-standard-reductions output-format grammar-map))
          :start-production start-production
          :output-format output-format}))))

--- a/src/instaparse/cfg.cljc
+++ b/src/instaparse/cfg.cljc
@@ -50,9 +50,9 @@
 
 (def opt-whitespace (hide (nt :opt-whitespace)))
 
-(def cfg 
-  (apply-standard-reductions 
-    :hiccup    ; use the hiccup output format 
+(def cfg
+  (apply-standard-reductions
+    :hiccup    ; use the hiccup output format
     {:rules (hide-tag (cat opt-whitespace
                            (plus (nt :rule))))
      :comment (cat (string "(*") (nt :inside-comment) (string "*)"))
@@ -73,7 +73,7 @@
                 opt-whitespace
                 (nt :alt-or-ord)
                 (hide (alt (nt :opt-whitespace)
-                           (cat (nt :opt-whitespace) (alt (string ";") (string ".")) (nt :opt-whitespace)))))          
+                           (cat (nt :opt-whitespace) (alt (string ";") (string ".")) (nt :opt-whitespace)))))
      :nt (cat
            (neg (nt :epsilon))
            (regexp
@@ -84,7 +84,7 @@
                         opt-whitespace
                         (hide (string ">")))
           :alt-or-ord (hide-tag (alt (nt :alt) (nt :ord)))
-          :alt (cat (nt :cat)                           
+          :alt (cat (nt :cat)
                     (star
                       (cat
                         opt-whitespace
@@ -104,7 +104,7 @@
                       opt-whitespace
                       (hide (string ")")))
           :hide (cat (hide (string "<"))
-                     opt-whitespace	
+                     opt-whitespace
                      (nt :alt-or-ord)
                      opt-whitespace
                      (hide (string ">")))
@@ -153,7 +153,7 @@
           :factor (hide-tag (alt (nt :nt)
                                  (nt :string)
                                  (nt :regexp)
-                                 (nt :opt)     
+                                 (nt :opt)
                                  (nt :star)
                                  (nt :plus)
                                  (nt :paren)
@@ -184,7 +184,7 @@
                "Encountered backslash character at end of string: " s))
         \" (recur (next sq) (conj v \\ \"))
         (recur (next sq) (conj v c)))
-      (apply str v))))                     
+      (apply str v))))
 
 ;(defn safe-read-string [s]
 ;  (binding [*read-eval* false]
@@ -224,7 +224,7 @@
         remove-escaped-single-quotes
         (escape stripped)
         final-string
-        (safe-read-string (str remove-escaped-single-quotes \"))]            
+        (safe-read-string (str remove-escaped-single-quotes \"))]
 
     final-string))
 
@@ -239,7 +239,7 @@
         final-string
         (re-pattern remove-escaped-single-quotes)]
 ;        (safe-read-regexp (str remove-escaped-single-quotes \"))]
-        
+
     final-string))
 
 ;;; Now we need to convert the grammar's parse tree into combinators
@@ -277,9 +277,9 @@
     (:string :string-ci :char :regexp :epsilon) []
     (:opt :plus :star :look :neg :rep) (recur (:parser parser))
     (:alt :cat) (mapcat seq-nt (:parsers parser))
-    :ord (mapcat seq-nt 
-                 [(:parser1 parser) (:parser2 parser)])))                 
-    
+    :ord (mapcat seq-nt
+                 [(:parser1 parser) (:parser2 parser)])))
+
 (defn check-grammar
   "Throw error if grammar uses any invalid non-terminals in its productions"
   [grammar-map]
@@ -290,7 +290,7 @@
           (subs (str nt) 1)
           " occurs on the right-hand side of your grammar, but not on the left"))))
   grammar-map)
-          
+
 (defn build-parser [spec output-format]
   (let [rules (parse cfg :rules spec false)]
     (if (instance? instaparse.gll.Failure rules)
@@ -298,7 +298,7 @@
         "Error parsing grammar specification:\n"
         (with-out-str (println rules)))
       (let [productions (map build-rule rules)
-            start-production (first (first productions))] 
+            start-production (first (first productions))]
         {:grammar (check-grammar (apply-standard-reductions output-format (into {} productions)))
          :start-production start-production
          :output-format output-format}))))
@@ -314,7 +314,7 @@
 (defn ebnf
   "Takes an EBNF grammar specification string and returns the combinator version.
 If you give it the right-hand side of a rule, it will return the combinator equivalent.
-If you give it a series of rules, it will give you back a grammar map.   
+If you give it a series of rules, it will give you back a grammar map.
 Useful for combining with other combinators."
   [spec & {:as opts}]
   (binding [*case-insensitive-literals* (:string-ci opts :default)]

--- a/src/instaparse/util.cljc
+++ b/src/instaparse/util.cljc
@@ -1,16 +1,20 @@
 (ns instaparse.util)
 
+;; Both appear to be called with several strings as separate
+;; arguments:
 (defn throw-runtime-exception
   [& message]
-  (-> (apply str message)
-      #?(:clj RuntimeException.)
-      throw))
+  (let [^String text (apply str message)]
+    (-> text
+        #?(:clj RuntimeException.)
+        throw)))
 
 (defn throw-illegal-argument-exception
   [& message]
-  (-> (apply str message)
-      #?(:clj IllegalArgumentException.)
-      throw))
+  (let [^String text (apply str message)]
+    (-> text
+        #?(:clj IllegalArgumentException.)
+        throw)))
 
 #?(:cljs
     (defn regexp-flags [re]


### PR DESCRIPTION
I tried to compile a dependent project with "native-image" of GraalVM fame. Reflection is a real problem there.

The other two are inessential whitespace only: "git diff -b" neutral.