### PR TITLE
Set global *warn-on-reflection* = true

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -36,6 +36,9 @@
             [cljsee "0.1.0"]]
   ;:hooks [leiningen.cljsbuild]
   :target-path "target"
+  ;; Instaparse sources  are reflection  free as  of 1.4.10,  the only
+  ;; reflection warnings seen so far come from the CLJS compiler:
+  :global-vars {*warn-on-reflection* true}
   :scm {:name "git"
         :url "https://github.com/Engelberg/instaparse"}
   :prep-tasks [["cljsee" "once"]]


### PR DESCRIPTION
Now that Instaparse is reflection-free maybe consider adding this flag?

https://clojuredocs.org/clojure.core/*warn-on-reflection*

I am not quite sure how far the side effects can go.