### PR TITLE
Fixed for issue #200. Corrects positioning of '^' when error line has tabs.

### DIFF
--- a/src/instaparse/failure.cljc
+++ b/src/instaparse/failure.cljc
@@ -84,5 +84,3 @@
     (doseq [r partial-reasons]
       (print-reason r)
       (println))))
-  
-(defn sun-glasses [] "...at night...so I can...")

--- a/src/instaparse/failure.cljc
+++ b/src/instaparse/failure.cljc
@@ -30,11 +30,17 @@
          :else (recur (next chars) n)))))
 
 (defn marker
-  "Creates string with caret at nth position, 1-based"
-  [n]
-  (when (integer? n)
-    (if (<= n 1) "^"
-      (apply str (concat (repeat (dec n) \space) [\^]))))) 
+  "Creates string with caret at nth position, 1-based
+   and accounts for horizontal tabs which might change
+   the alignment of the '^' to the error location."
+  [text n]
+  (when (and text (integer? n))
+    (let [marker-text (clojure.string/replace text #"[.[^\s]]" " ")]
+      (if (<= n 1)
+          "^"
+          (str (subs marker-text 0 (dec n)) \^)))))
+
+;; (apply str (concat (repeat (dec n) \space) [\^]))           
       
 (defn augment-failure
   "Adds text, line, and column info to failure object."
@@ -65,7 +71,7 @@
   [{:keys [line column text reason]}]
   (println (str "Parse error at line " line ", column " column ":"))
   (println text)
-  (println (marker column))
+  (println (marker text column))
   (let [full-reasons (distinct (map :expecting
                                     (filter :full reason)))
         partial-reasons (distinct (map :expecting
@@ -81,3 +87,4 @@
       (print-reason r)
       (println))))
   
+(defn sun-glasses [] "...at night...so I can...")

--- a/src/instaparse/failure.cljc
+++ b/src/instaparse/failure.cljc
@@ -39,8 +39,6 @@
       (if (<= n 1)
           "^"
           (str (subs marker-text 0 (dec n)) \^)))))
-
-;; (apply str (concat (repeat (dec n) \space) [\^]))           
       
 (defn augment-failure
   "Adds text, line, and column info to failure object."

--- a/test/instaparse/failure_test.cljc
+++ b/test/instaparse/failure_test.cljc
@@ -1,0 +1,33 @@
+(ns instaparse.failure-test
+  (:require
+    #?(:clj  [instaparse.failure :refer [marker pprint-failure]]
+       :cljs [instaparse.failure :refer [marker pprint-failure]])
+    #?(:clj [clojure.test :refer [deftest are is]]
+       :cljs [cljs.test]))
+  #?(:cljs (:require-macros
+             [cljs.test :refer [is are deftest]])))
+
+;; Tests new marker function by counting the number of tabs in both text
+;; and marker lines to make sure the count is the same.
+(deftest marker-test
+  (let [text           "\t\ti'm a sample error line with tabs."
+        n              16
+        marker         (marker text n)
+        text-matcher   (re-matcher #"\t" text)
+        marker-matcher (re-matcher #"\t" marker)]
+    (re-find text-matcher)
+    (re-find marker-matcher)
+    (let [text-tabs   (count (re-groups text-matcher))
+          marker-tabs (count (re-groups marker-matcher))]
+      (is (= text-tabs marker-tabs)))))
+
+;; No assertions but should print marker line with caret under 'e' in error.
+(deftest pprint-failure-test
+  (let [request {:line 3
+                 :column 16
+                 :text "\t\ti'm a sample error line with tabs."
+                 :reason "for testing"}]
+    (println "Test passes if '^' appears under the 'e' in 'error':")
+    (pprint-failure request)
+    ;; Just testing for no exceptions here.
+    (is (= 1 1))))


### PR DESCRIPTION
**What:** Marker '^' added after error line is often misaligned with error column. This is most often due to tabs.

**How:** 'marker' function in 'failure.cljc' has been updated. marker line is now a regex replace of the text error line where all space characters are retained and regular characters are converted to spaces.

**Tests:** Added failure-test.cljc containing 2 tests: 1) Tests marker function confirming tab count in marker line matches tab count of text line. 2) Test pprint-failure. See code comments.