### PR TITLE
Fix #200. Corrects positioning of '^' when error line has tabs. (Supersedes PR #201)

### DIFF
--- a/runner/cljs/runner/runner.cljs
+++ b/runner/cljs/runner/runner.cljs
@@ -4,6 +4,7 @@
             [instaparse.auto-flatten-seq-test]
             [instaparse.core-test]
             [instaparse.defparser-test]
+            [instaparse.failure-test]
             [instaparse.grammars]
             [instaparse.repeat-test]
             [instaparse.specs]
@@ -23,6 +24,7 @@
              'instaparse.auto-flatten-seq-test
              'instaparse.core-test
              'instaparse.defparser-test
+             'instaparse.failure-test
              'instaparse.grammars
              'instaparse.repeat-test
              'instaparse.specs))

--- a/src/instaparse/failure.cljc
+++ b/src/instaparse/failure.cljc
@@ -84,5 +84,3 @@
     (doseq [r partial-reasons]
       (print-reason r)
       (println))))
-  
-(defn sun-glasses [] "...at night...so I can...")

--- a/src/instaparse/failure.cljc
+++ b/src/instaparse/failure.cljc
@@ -30,11 +30,17 @@
          :else (recur (next chars) n)))))
 
 (defn marker
-  "Creates string with caret at nth position, 1-based"
-  [n]
-  (when (integer? n)
-    (if (<= n 1) "^"
-      (apply str (concat (repeat (dec n) \space) [\^]))))) 
+  "Creates string with caret at nth position, 1-based
+   and accounts for horizontal tabs which might change
+   the alignment of the '^' to the error location."
+  [text n]
+  (when (and text (integer? n))
+    (let [marker-text (clojure.string/replace text #"[.[^\s]]" " ")]
+      (if (<= n 1)
+          "^"
+          (str (subs marker-text 0 (dec n)) \^)))))
+
+;; (apply str (concat (repeat (dec n) \space) [\^]))           
       
 (defn augment-failure
   "Adds text, line, and column info to failure object."
@@ -65,7 +71,7 @@
   [{:keys [line column text reason]}]
   (println (str "Parse error at line " line ", column " column ":"))
   (println text)
-  (println (marker column))
+  (println (marker text column))
   (let [full-reasons (distinct (map :expecting
                                     (filter :full reason)))
         partial-reasons (distinct (map :expecting
@@ -81,3 +87,4 @@
       (print-reason r)
       (println))))
   
+(defn sun-glasses [] "...at night...so I can...")

--- a/src/instaparse/failure.cljc
+++ b/src/instaparse/failure.cljc
@@ -39,8 +39,6 @@
       (if (<= n 1)
           "^"
           (str (subs marker-text 0 (dec n)) \^)))))
-
-;; (apply str (concat (repeat (dec n) \space) [\^]))           
       
 (defn augment-failure
   "Adds text, line, and column info to failure object."

--- a/src/instaparse/failure.cljc
+++ b/src/instaparse/failure.cljc
@@ -35,7 +35,7 @@
    the alignment of the '^' to the error location."
   [text n]
   (when (and text (integer? n))
-    (let [marker-text (clojure.string/replace text #"[.[^\s]]" " ")]
+    (let [marker-text (clojure.string/replace text #"[^\s]" " ")]
       (if (<= n 1)
           "^"
           (str (subs marker-text 0 (dec n)) \^)))))

--- a/test/instaparse/failure_test.cljc
+++ b/test/instaparse/failure_test.cljc
@@ -20,10 +20,11 @@
   (let [request {:line 3
                  :column 16
                  :text "\t\ti'm a sample error line with tabs."
-                 :reason [{:tag :string :expecting "A"}]}]
+                 :reason [{:tag :string :expecting "A"}]}
+        nl (println-str)]
     (is (= (with-out-str (pprint-failure request))
-           (str "Parse error at line 3, column 16:\n"
-                (:text request) "\n"
-                "\t\t             ^\n"
-                "Expected:\n"
-                "\"A\"\n")))))
+           (str "Parse error at line 3, column 16:" nl
+                (:text request) nl
+                "\t\t             ^" nl
+                "Expected:" nl
+                "\"A\"" nl)))))

--- a/test/instaparse/failure_test.cljc
+++ b/test/instaparse/failure_test.cljc
@@ -1,0 +1,33 @@
+(ns instaparse.failure-test
+  (:require
+    #?(:clj  [instaparse.failure :refer [marker pprint-failure]]
+       :cljs [instaparse.failure :refer [marker pprint-failure]])
+    #?(:clj [clojure.test :refer [deftest are is]]
+       :cljs [cljs.test]))
+  #?(:cljs (:require-macros
+             [cljs.test :refer [is are deftest]])))
+
+;; Tests new marker function by counting the number of tabs in both text
+;; and marker lines to make sure the count is the same.
+(deftest marker-test
+  (let [text           "\t\ti'm a sample error line with tabs."
+        n              16
+        marker         (marker text n)
+        text-matcher   (re-matcher #"\t" text)
+        marker-matcher (re-matcher #"\t" marker)]
+    (re-find text-matcher)
+    (re-find marker-matcher)
+    (let [text-tabs   (count (re-groups text-matcher))
+          marker-tabs (count (re-groups marker-matcher))]
+      (is (= text-tabs marker-tabs)))))
+
+;; No assertions but should print marker line with caret under 'e' in error.
+(deftest pprint-failure-test
+  (let [request {:line 3
+                 :column 16
+                 :text "\t\ti'm a sample error line with tabs."
+                 :reason "for testing"}]
+    (println "Test passes if '^' appears under the 'e' in 'error':")
+    (pprint-failure request)
+    ;; Just testing for no exceptions here.
+    (is (= 1 1))))

--- a/test/instaparse/failure_test.cljc
+++ b/test/instaparse/failure_test.cljc
@@ -12,13 +12,9 @@
 (deftest marker-test
   (let [text           "\t\ti'm a sample error line with tabs."
         n              16
-        marker         (marker text n)
-        text-matcher   (re-matcher #"\t" text)
-        marker-matcher (re-matcher #"\t" marker)]
-    (re-find text-matcher)
-    (re-find marker-matcher)
-    (let [text-tabs   (count (re-groups text-matcher))
-          marker-tabs (count (re-groups marker-matcher))]
+        marker         (marker text n)]
+    (let [text-tabs   (count (filter #{"\t"} text))
+          marker-tabs (count (filter #{"\t"} marker))]
       (is (= text-tabs marker-tabs)))))
 
 ;; No assertions but should print marker line with caret under 'e' in error.

--- a/test/instaparse/failure_test.cljc
+++ b/test/instaparse/failure_test.cljc
@@ -17,13 +17,14 @@
           marker-tabs (count (filter #{"\t"} marker))]
       (is (= text-tabs marker-tabs)))))
 
-;; No assertions but should print marker line with caret under 'e' in error.
 (deftest pprint-failure-test
   (let [request {:line 3
                  :column 16
                  :text "\t\ti'm a sample error line with tabs."
-                 :reason "for testing"}]
-    (println "Test passes if '^' appears under the 'e' in 'error':")
-    (pprint-failure request)
-    ;; Just testing for no exceptions here.
-    (is (= 1 1))))
+                 :reason [{:tag :string :expecting "A"}]}]
+    (is (= (with-out-str (pprint-failure request))
+           (str "Parse error at line 3, column 16:\n"
+                (:text request) "\n"
+                "\t\t             ^\n"
+                "Expected:\n"
+                "\"A\"\n")))))

--- a/test/instaparse/failure_test.cljc
+++ b/test/instaparse/failure_test.cljc
@@ -1,7 +1,6 @@
 (ns instaparse.failure-test
   (:require
-    #?(:clj  [instaparse.failure :refer [marker pprint-failure]]
-       :cljs [instaparse.failure :refer [marker pprint-failure]])
+    [instaparse.failure :refer [marker pprint-failure]]
     #?(:clj [clojure.test :refer [deftest are is]]
        :cljs [cljs.test]))
   #?(:cljs (:require-macros


### PR DESCRIPTION
I fixed the pprint-failure-test as discussed in #201. While doing this I noticed that the original patch didn't work correctly in ClojureScript and fixed that too.