### PR TITLE
instaparse.core/parser: Add :start-production in :else clause

### DIFF
--- a/src/instaparse/core.cljc
+++ b/src/instaparse/core.cljc
@@ -253,7 +253,8 @@
           #?(:clj
              (let [spec (slurp grammar-specification)
                    parser (build-parser spec output-format)]
-               (map->Parser parser))
+               (if start (map->Parser (assoc parser :start-production start))
+                 (map->Parser parser)))
              :cljs
              (throw-illegal-argument-exception
               "Expected string, map, or vector as grammar specification, got "


### PR DESCRIPTION
I found a minor error in the behaviour of instaparse.core/parser with respect to assignment of start production.  The issue can be seen from this example:

```
user> (let [f  "test.bnf"
            g1 (io/file f)
            g2 (slurp g1)
            pars #(instaparse.core/parser % :start :other)
            p1 (pars g1)
            p2 (pars g2)]
        {:g1 g1
         :g2 g2
         :start1 (:start-production p1)
         :start2 (:start-production p2)
         :same? (= p1 p2)
         :otherwise-same? (= (dissoc p1 :start-production) (dissoc p2 :start-production))})
{:g1 #object[java.io.File 0x28920de7 "test.bnf"],
 :g2 "rule = \"xxx\"\n",
 :start1 :rule,
 :start2 :other,
 :same? false,
 :otherwise-same? true}
user> 
```

in which the start production of the grammar `rule = "xxx"` (in file `test.bnf`) depends on whether the grammar is provided to `parser` as either a string or a file/resource object: In the above example start production is `:rule` in the former and `:other` in the latter.

The PR provides a straightforward fix.

-Klaus.