### PR TITLE
Make it easier to refer `instaparse.core/defparser` from modern ClojureScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ provided that, if given a string for a grammar specification, will
 parse that as a grammar up front and emit more performant code.
 
 ```clojure
-;; Clojure
+;; Clojure (all versions) and ClojureScript (1.9.198 and above)
 (:require [instaparse.core :as insta :refer [defparser]])
-;; ClojureScript
+;; ClojureScript (prior to 1.9.198)
 (:require [instaparse.core :as insta :refer-macros [defparser]])
 
 => (time (def p (insta/parser "S = A B; A = 'a'+; B = 'b'+")))

--- a/src/instaparse/core.cljc
+++ b/src/instaparse/core.cljc
@@ -1,7 +1,7 @@
 (ns instaparse.core
-  (#?(:clj :require :cljs :require-macros)
-    [instaparse.macros :refer [defclone
-                               set-global-var!]])
+  #?(:cljs
+     (:require-macros [instaparse.core]
+                      [instaparse.macros :refer [defclone set-global-var!]]))
   (:require [clojure.walk :as walk]
             [instaparse.gll :as gll]
             [instaparse.cfg :as cfg]
@@ -14,7 +14,8 @@
             [instaparse.combinators-source :as c]
             [instaparse.line-col :as lc]
             [instaparse.viz :as viz]
-            [instaparse.util :refer [throw-illegal-argument-exception]]))
+            [instaparse.util :refer [throw-illegal-argument-exception]]
+            #?(:clj [instaparse.macros :refer [defclone set-global-var!]])))
 
 (def ^:dynamic *default-output-format* :hiccup)
 (defn set-default-output-format!


### PR DESCRIPTION
- As of ClojureScript 1.9.198, a .cljs namespace can expose macros from the corresponding .clj namespace; consumers of the .cljs namespace address vars (from the .cljs ns) and macros (from the .clj ns) without additional `:require-macros`/`:include-macros`/`:refer-macros`:
    - https://clojure.atlassian.net/browse/CLJS-1507
    - https://clojurescript.org/guides/ns-forms#_implicit_sugar
- Since this is a .cljc file, we need to use a reader conditional:
    - https://code.thheller.com/blog/shadow-cljs/2019/10/12/clojurescript-macros.html#gotcha-5-cljc