### PR TITLE
Support *print-readably* for Failure and Parser print-method

### DIFF
--- a/src/instaparse/core.cljc
+++ b/src/instaparse/core.cljc
@@ -160,8 +160,10 @@
 
 #?(:clj
    (defmethod clojure.core/print-method Parser [x writer]
-     (binding [*out* writer]
-       (println (print/Parser->str x))))
+     (if *print-readably*
+       (print-method (print/Parser->str x) writer)
+       (binding [*out* writer]
+         (println (print/Parser->str x)))))
    :cljs
    (extend-protocol IPrintWithWriter
      instaparse.core/Parser

--- a/src/instaparse/gll.cljc
+++ b/src/instaparse/gll.cljc
@@ -181,8 +181,13 @@
 
 #?(:clj
    (defmethod clojure.core/print-method Failure [x writer]
-     (binding [*out* writer]
-       (fail/pprint-failure x)))
+     (if *print-readably*
+       (print-method
+         (with-out-str
+           (fail/pprint-failure x))
+         writer)
+       (binding [*out* writer]
+         (fail/pprint-failure x))))
    :cljs
    (extend-protocol IPrintWithWriter
      instaparse.gll/Failure


### PR DESCRIPTION
This is important for machine-readable REPLs like nREPL and Clojure Sublimed Socket REPL to operate. They have to print values to send them over the network in machine-readable format. Similar to what `prn` does compared to `println`

Before:
<img width="460" alt="Screenshot 2023-10-04 at 16 43 21" src="https://github.com/Engelberg/instaparse/assets/285292/d5623f50-8a35-4827-9f85-1679d4dbc918">

After:
<img width="370" alt="Screenshot 2023-10-04 at 16 43 06" src="https://github.com/Engelberg/instaparse/assets/285292/298b0fde-7759-4015-8ca1-e12e7d8f46f8">

